### PR TITLE
User and Admin role implementation

### DIFF
--- a/controllers/user_controller.js
+++ b/controllers/user_controller.js
@@ -43,12 +43,18 @@ const loginUser = async (req, res) => {
     if (passwordMatch) {
         // create access and refresh tokens
         const accessToken = jwt.sign(
-            { email: req.body.email },
+            {
+                email: req.body.email,
+                role: foundUser.role,
+            },
             process.env.ACCESS_TOKEN_SECRET,
             { expiresIn: "5m" }
         )
         const refreshToken = jwt.sign(
-            { email: req.body.email },
+            {
+                email: req.body.email,
+                role: foundUser.role,
+            },
             process.env.REFRESH_TOKEN_SECRET,
             { expiresIn: "7d" }
         )
@@ -99,8 +105,12 @@ const giveNewAccessToken = async (req, res) => {
             } else if (foundUser.email !== decoded.email) {
                 return res.status(403).send({ error: "refresh token invalid" })
             } else {
+                console.log(decoded)
                 const accessToken = jwt.sign(
-                    { email: foundUser.email },
+                    {
+                        email: req.body.email,
+                        role: foundUser.role,
+                    },
                     process.env.ACCESS_TOKEN_SECRET,
                     { expiresIn: "5min" }
                 )

--- a/db/user_model.js
+++ b/db/user_model.js
@@ -16,8 +16,14 @@ const UserModel = mongoose.model("User", {
         required: [true, "a password is required"],
     },
     refresh_token: {
-        type: String
-    }
+        type: String,
+    },
+    role: {
+        type: String,
+        enum: { values: ["user", "admin"] },
+        default: "user",
+        required: true,
+    },
 })
 
 module.exports = UserModel

--- a/middleware/admin_auth.js
+++ b/middleware/admin_auth.js
@@ -1,0 +1,13 @@
+// must be called after jwt_authorize middleware
+const authorizeAdmin = (req, res, next) => {
+    if (!req?.role) {
+        return res.status(401).send({ error: "user role not present" })
+    }
+
+    if (req.role !== "admin") {
+        return res.status(401).send({ error: "must be an admin" })
+    }
+    next()
+}
+
+module.exports = authorizeAdmin

--- a/middleware/jwt_auth.js
+++ b/middleware/jwt_auth.js
@@ -2,7 +2,7 @@ const jwt = require("jsonwebtoken")
 
 const jwtAuthorize = (req, res, next) => {
     const authHeader = req.headers["authorization"]
-    if (!authHeader) {
+    if (!authHeader?.startsWith("Bearer ")) {
         return res
             .status(401)
             .send({ error: "authorization header not present" })
@@ -12,9 +12,11 @@ const jwtAuthorize = (req, res, next) => {
     const token = authHeader.split(" ")[1]
     jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err, decrypted) => {
         if (err) {
-            return res.status(403).send({ error: "invalid token"})
+            return res.status(403).send({ error: "invalid token" })
         }
-        req.email = decrypted.email //hand verified user email to req
+        //hand verified user email and role to req body
+        req.email = decrypted.email
+        req.role = decrypted.role
         next()
     })
 }

--- a/routes/topic_routes.js
+++ b/routes/topic_routes.js
@@ -1,12 +1,13 @@
 const express = require("express")
 const router = express.Router()
 const topicController = require("../controllers/topic_controller")
-const jwtAuthorize = require("../middleware/jwt_authorize")
+const jwtAuthorize = require("../middleware/jwt_auth")
+const adminAuth = require("../middleware/admin_auth")
 
 router
     .route("/")
     .get(topicController.getAllTopics)
-    .post(jwtAuthorize, topicController.createNewTopic)
+    .post(jwtAuthorize, adminAuth, topicController.createNewTopic)
 
 router
     .route("/:id")


### PR DESCRIPTION
Updated user model to contain a role field, and modified JWT token to include role.

Created a simple admin-only authorization middleware. Applied it to the topic route and tested.

_Note that users can only have one role at a time, and the admin role must be added by manually adding the role by editing the user role in Atlas database._